### PR TITLE
Fix: Customer Login Error on Controller Forward

### DIFF
--- a/src/module-kount-control/Plugin/Controller/Account/LoginPost.php
+++ b/src/module-kount-control/Plugin/Controller/Account/LoginPost.php
@@ -7,7 +7,7 @@
 namespace Kount\KountControl\Plugin\Controller\Account;
 
 use Magento\Framework\App\Action\HttpPostActionInterface;
-use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\AbstractResult;
 
 class LoginPost
 {
@@ -72,7 +72,7 @@ class LoginPost
      * @param Redirect $result
      * @return Redirect
      */
-    public function afterExecute(HttpPostActionInterface $httpPostAction, Redirect $result)
+    public function afterExecute(HttpPostActionInterface $httpPostAction, AbstractResult $result)
     {
         $this->customerSession->set2faSuccessful(true);
         $sessionId = '';


### PR DESCRIPTION
Prevents the following error from being encountered on customer login: "Kount\KountControl\Plugin\Controller\Account\LoginPost::afterExecute(): Argument #2 ($result) must be of type Magento\Framework\Controller\Result\Redirect, Magento\Framework\Controller\Result\Forward\Interceptor given, called in .../vendor/magento/framework/Interception/Interceptor.php on line 146 and defined in .../vendor/kount/magento2-kount/src/module-kount-control/Plugin/Controller/Account/LoginPost.php:75"

Fixes #22 